### PR TITLE
Regenerate Makefile.in

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -445,6 +445,7 @@ baseboard_DATA = \
 	baseboards/multi-sim.exp \
 	baseboards/powerpc-sim.exp \
 	baseboards/powerpcle-sim.exp \
+	baseboards/riscv-sim.exp \
 	baseboards/rx-sim.exp \
 	baseboards/sh-sid.exp \
 	baseboards/sh-sim.exp \


### PR DESCRIPTION
The prevents getting `ERROR: couldn't load description file for riscv-sim` when attempting to use an installed DejaGnu (or having to regenerate it yourself first).