### PR TITLE
Add gdb sim and newlib nano support.  Install riscv files.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -110,6 +110,8 @@ baseboard_DATA = \
 	baseboards/powerpc-sim.exp \
 	baseboards/powerpcle-sim.exp \
 	baseboards/riscv-sim.exp \
+	baseboards/riscv-sim-gdb.exp \
+	baseboards/riscv-sim-nano.exp \
 	baseboards/rx-sim.exp \
 	baseboards/sh-sid.exp \
 	baseboards/sh-sim.exp \

--- a/Makefile.in
+++ b/Makefile.in
@@ -446,6 +446,8 @@ baseboard_DATA = \
 	baseboards/powerpc-sim.exp \
 	baseboards/powerpcle-sim.exp \
 	baseboards/riscv-sim.exp \
+	baseboards/riscv-sim-gdb.exp \
+	baseboards/riscv-sim-nano.exp \
 	baseboards/rx-sim.exp \
 	baseboards/sh-sid.exp \
 	baseboards/sh-sim.exp \

--- a/baseboards/riscv-sim-gdb.exp
+++ b/baseboards/riscv-sim-gdb.exp
@@ -1,0 +1,55 @@
+# Copyright (C) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2012, 2016
+# Free Software Foundation, Inc.
+#
+# This file is part of DejaGnu. For RISC-V target simulation.
+#
+# DejaGnu is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# DejaGnu is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with DejaGnu; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.
+
+# Load the generic configuration for this board. This will define a basic
+# set of routines used to communicate with the board.
+load_generic_config "sim"
+
+# basic-sim.exp is a basic description for the standard Cygnus simulator.
+load_base_board_description "basic-sim"
+
+# This tells it which directory to look in for the simulator.
+setup_sim riscv
+
+# No multilib flags are set by default.
+process_multilib_options ""
+
+# The compiler used to build for this board. This has *nothing* to do
+# with what compiler is tested if we're testing gcc.
+set_board_info compiler "[find_gcc]"
+
+# The basic set of flags needed to build "hello world" for this
+# board. This board uses libgloss and newlib.
+set_board_info cflags 	"[libgloss_include_flags] [newlib_include_flags]"
+set_board_info ldflags 	"--specs=sim.specs [libgloss_link_flags] [newlib_link_flags]"
+
+# This board doesn't use a linker script.
+set_board_info ldscript ""
+
+# And, it can't do arguments, and doesn't have real signals.
+
+set_board_info noargs 1
+set_board_info gdb,nosignals 1
+
+# skip gdb.reverse
+set_board_info gdb,can_reverse 0
+set_board_info gdb,use_precord 0
+
+# Setup the timeout
+set_board_info gcc,timeout 600

--- a/baseboards/riscv-sim-nano.exp
+++ b/baseboards/riscv-sim-nano.exp
@@ -1,0 +1,55 @@
+# Copyright (C) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2012, 2016
+# Free Software Foundation, Inc.
+#
+# This file is part of DejaGnu. For RISC-V target simulation.
+#
+# DejaGnu is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# DejaGnu is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with DejaGnu; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.
+
+# Load the generic configuration for this board. This will define a basic
+# set of routines used to communicate with the board.
+load_generic_config "sim"
+
+# basic-sim.exp is a basic description for the standard Cygnus simulator.
+load_base_board_description "basic-sim"
+
+# This tells it which directory to look in for the simulator.
+setup_sim riscv
+
+# No multilib flags are set by default.
+process_multilib_options ""
+
+# The compiler used to build for this board. This has *nothing* to do
+# with what compiler is tested if we're testing gcc.
+set_board_info compiler "[find_gcc]"
+
+# The basic set of flags needed to build "hello world" for this
+# board. This board uses libgloss and newlib.
+set_board_info cflags 	"[libgloss_include_flags] [newlib_include_flags]"
+set_board_info ldflags 	"--specs=nano.specs [libgloss_link_flags] [newlib_link_flags]"
+
+# This board doesn't use a linker script.
+set_board_info ldscript ""
+
+# And, it can't do arguments, and doesn't have real signals.
+
+set_board_info noargs 1
+set_board_info gdb,nosignals 1
+
+# skip gdb.reverse
+set_board_info gdb,can_reverse 0
+set_board_info gdb,use_precord 0
+
+# Setup the timeout
+set_board_info gcc,timeout 600


### PR DESCRIPTION
	* Makefile.am (baseboard_DATA): Add riscv-sim.exp, riscv-sim-gdb.exp,
	and riscv-sim-nano.exp.
	* Makefile.in: Regenerate.
	* baseboards/riscv-sim-gdb.exp: New.
	* baseboards/riscv-sim-nano.exp: New.