### PR TITLE
Add riscv-gvsoc.exp baseboard: target board for gvsoc simulator.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -109,6 +109,7 @@ baseboard_DATA = \
 	baseboards/multi-sim.exp \
 	baseboards/powerpc-sim.exp \
 	baseboards/powerpcle-sim.exp \
+	baseboards/riscv-gvsoc.exp \
 	baseboards/riscv-sim.exp \
 	baseboards/riscv-sim-gdb.exp \
 	baseboards/riscv-sim-nano.exp \

--- a/baseboards/riscv-gvsoc.exp
+++ b/baseboards/riscv-gvsoc.exp
@@ -1,0 +1,28 @@
+# Load the generic configuration for this board.  This will define any
+# routines needed to communicate with the board.
+load_generic_config "sim"
+
+set_board_info sim "gvsoc_sim"
+set_board_info sim,options ""
+set_board_info is_simulator 1
+
+# No default multilib options are needed for this board.
+process_multilib_options ""
+
+set_board_info cflags    ""
+
+set_board_info ldflags   "$::env(PULP_SDK_HOME)/libs/libbasic-runtime.a -nostartfiles -Wl,--gc-sections -L$::env(PULP_SDK_HOME)/rtos/pulpos/pulp/kernel -Tchips/pulp/link_huge_stack_model.ld -lgcc"
+
+# No linker script needed.
+set_board_info ldscript ""
+
+# No support for signals on this target.
+set_board_info gdb,nosignals 1
+set_board_info gcc,stack_size 32768
+
+# L2 memory available without stack, heap and other segments (20kB)
+set_board_info gcc,memory_size 435000
+
+
+# Set timeout
+set_board_info gcc,timeout 10


### PR DESCRIPTION
Files changed:

	*baseboards/riscv-gvsoc.exp: Add baseboards/riscv-gvsoc.exp.
	*Makefile.am: Update baseboard_DATA with riscv-gvsoc.exp.

Signed-off-by: Enrico Tabanelli <enrico.tabanelli@embecosm.com>